### PR TITLE
Inverted Board for Black Player

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ renderer.Render(options)
 
 Specify the path of the image assets for the individual pieces. Feel free to use the assets packaged in this repo, but be aware they are under CC license.
 
+#### Inverted (`false`)
+
+Invert the board so that it displays correctly for the black player. By default the white player view is rendered. This is a boolean option.
+
 #### Resizer (`draw.CatmullRom`)
 
 Change the algorhythm for asset resizing. Depending on your performance requirements, you may need to use a faster (but more lossy) resizing method (like `draw.NearestNeighbor`).

--- a/board.go
+++ b/board.go
@@ -9,8 +9,16 @@ func (s Tile) rank() int {
 	return int(int(s) / 8)
 }
 
+func (s Tile) rankInverted() int {
+	return 7 - s.rank()
+}
+
 func (s Tile) file() int {
 	return int(s) % 8
+}
+
+func (s Tile) fileInverted() int {
+	return 7 - s.file()
 }
 
 func tileFromRankFile(rank int, file int) Tile {

--- a/examples/king_checked_inverted.go
+++ b/examples/king_checked_inverted.go
@@ -1,0 +1,28 @@
+// --+build ignore
+
+package main
+
+import (
+	"image/png"
+	"log"
+	"os"
+
+	"github.com/cjsaylor/chessimage"
+)
+
+func main() {
+	board, err := chessimage.NewRendererFromFEN("r1r3k1/4bp2/ppn5/3pP1N1/1P1P1Pq1/P1NQ3b/3B1P2/R1R3K1 w - - 1 24")
+	if err != nil {
+		log.Fatalln(err)
+	}
+	board.SetLastMove(chessimage.LastMove{
+		From: chessimage.D7,
+		To:   chessimage.G4,
+	})
+	board.SetCheckTile(chessimage.G1)
+	image, err := board.Render(chessimage.Options{AssetPath: "./assets/", Inverted: true})
+	if err != nil {
+		log.Fatalln(err)
+	}
+	png.Encode(os.Stdout, image)
+}

--- a/renderer.go
+++ b/renderer.go
@@ -25,10 +25,12 @@ var pieceNames = map[string]string{
 }
 
 const (
-	defaultBoardSize  = 512
-	defaultPieceRatio = 0.8
-	fileSymbols       = "abcdefgh"
-	rankSymbols       = "12345678"
+	defaultBoardSize   = 512
+	defaultPieceRatio  = 0.8
+	fileSymbols        = "abcdefgh"
+	fileSymbolsReverse = "hgfedcba"
+	rankSymbols        = "12345678"
+	rankSymbolsReverse = "87654321"
 )
 
 var (
@@ -200,7 +202,7 @@ func (r *Renderer) drawRankFile(o Options) error {
 	}
 
 	if o.Inverted {
-		symbols = reverse(fileSymbols)
+		symbols = fileSymbolsReverse
 	} else {
 		symbols = fileSymbols
 	}
@@ -218,7 +220,7 @@ func (r *Renderer) drawRankFile(o Options) error {
 	if o.Inverted {
 		symbols = rankSymbols
 	} else {
-		symbols = reverse(rankSymbols)
+		symbols = rankSymbolsReverse
 	}
 	for i, symbol := range symbols {
 		var color []int
@@ -275,12 +277,4 @@ func calcDrawSize(o Options) drawSize {
 		pieceSize:   int(pieceSize),
 		pieceOffset: int((gridSize - pieceSize) / 2),
 	}
-}
-
-func reverse(s string) string {
-	r := []rune(s)
-	for i, j := 0, len(r)-1; i < len(r)/2; i, j = i+1, j-1 {
-		r[i], r[j] = r[j], r[i]
-	}
-	return string(r)
 }

--- a/renderer.go
+++ b/renderer.go
@@ -25,10 +25,10 @@ var pieceNames = map[string]string{
 }
 
 const (
-	defaultBoardSize   = 512
-	defaultPieceRatio  = 0.8
-	fileSymbols        = "abcdefgh"
-	rankSymbolsReverse = "87654321"
+	defaultBoardSize  = 512
+	defaultPieceRatio = 0.8
+	fileSymbols       = "abcdefgh"
+	rankSymbols       = "12345678"
 )
 
 var (
@@ -50,6 +50,7 @@ type Options struct {
 	Resizer    draw.Scaler
 	BoardSize  int
 	PieceRatio float64
+	Inverted   bool
 }
 
 // Renderer is responsible for rendering the board, pieces, rank/file, and tile highlights
@@ -73,11 +74,13 @@ func NewRendererFromFEN(fen string) (*Renderer, error) {
 	}, nil
 }
 
+// SetCheckTile - Sets the check tile
 func (r *Renderer) SetCheckTile(tile Tile) {
 	// @todo validate it is within the range of proper tiles
 	r.checkTile = tile
 }
 
+// SetLastMove - Sets the last move
 func (r *Renderer) SetLastMove(lastMove LastMove) {
 	r.lastMove = &lastMove
 }
@@ -96,8 +99,8 @@ func (r *Renderer) Render(options Options) (image.Image, error) {
 	r.drawSize = calcDrawSize(options)
 	r.context = gg.NewContext(options.BoardSize, options.BoardSize)
 	r.drawBackground()
-	r.highlightCells()
-	r.drawCheckTile()
+	r.highlightCells(options)
+	r.drawCheckTile(options)
 	r.drawRankFile(options)
 	if err := r.drawBoard(options); err != nil {
 		return nil, err
@@ -120,34 +123,56 @@ func (r *Renderer) drawBackground() {
 	}
 }
 
-func (r *Renderer) highlightCells() {
+func (r *Renderer) highlightCells(o Options) {
 	if r.lastMove == nil {
 		return
 	}
+
+	var lastMoveFromRank, lastMoveToRank, lastMoveFromFile, lastMoveToFile int
+	if o.Inverted {
+		lastMoveFromRank = r.lastMove.From.rankInverted()
+		lastMoveFromFile = r.lastMove.From.fileInverted()
+		lastMoveToRank = r.lastMove.To.rankInverted()
+		lastMoveToFile = r.lastMove.To.fileInverted()
+	} else {
+		lastMoveFromRank = r.lastMove.From.rank()
+		lastMoveFromFile = r.lastMove.From.file()
+		lastMoveToRank = r.lastMove.To.rank()
+		lastMoveToFile = r.lastMove.To.file()
+	}
+
 	gridSize := r.drawSize.gridSize
 	r.context.DrawRectangle(
-		float64(r.lastMove.From.file()*gridSize),
-		float64(r.lastMove.From.rank()*gridSize),
+		float64(lastMoveFromFile*gridSize),
+		float64(lastMoveFromRank*gridSize),
 		float64(gridSize),
 		float64(gridSize))
 	r.context.SetRGB255(colorHighlight[0], colorHighlight[1], colorHighlight[2])
 	r.context.Fill()
 	r.context.DrawRectangle(
-		float64(r.lastMove.To.file()*gridSize),
-		float64(r.lastMove.To.rank()*gridSize),
+		float64(lastMoveToFile*gridSize),
+		float64(lastMoveToRank*gridSize),
 		float64(gridSize), float64(gridSize))
 	r.context.SetRGB255(colorHighlightDim[0], colorHighlightDim[1], colorHighlightDim[2])
 	r.context.Fill()
 }
 
-func (r *Renderer) drawCheckTile() {
+func (r *Renderer) drawCheckTile(o Options) {
 	if r.checkTile == NoTile {
 		return
 	}
+	var checkTileFile, checkTileRank int
+	if o.Inverted {
+		checkTileFile = r.checkTile.fileInverted()
+		checkTileRank = r.checkTile.rankInverted()
+	} else {
+		checkTileFile = r.checkTile.file()
+		checkTileRank = r.checkTile.rank()
+	}
 	gridSize := float64(r.drawSize.gridSize)
 	r.context.DrawRectangle(
-		float64(r.checkTile.file())*gridSize,
-		float64(r.checkTile.rank())*gridSize,
+		float64(checkTileFile)*gridSize,
+		float64(checkTileRank)*gridSize,
 		gridSize,
 		gridSize,
 	)
@@ -157,7 +182,7 @@ func (r *Renderer) drawCheckTile() {
 
 func (r *Renderer) drawBoard(o Options) error {
 	for _, position := range r.board {
-		if err := r.drawPiece(position, o.AssetPath, o.Resizer); err != nil {
+		if err := r.drawPiece(position, o.AssetPath, o.Resizer, o.Inverted); err != nil {
 			return err
 		}
 	}
@@ -165,6 +190,7 @@ func (r *Renderer) drawBoard(o Options) error {
 }
 
 func (r *Renderer) drawRankFile(o Options) error {
+	var symbols string
 	fontPath, err := findfont.Find("arial.ttf")
 	if err != nil {
 		return err
@@ -172,7 +198,13 @@ func (r *Renderer) drawRankFile(o Options) error {
 	if err := r.context.LoadFontFace(fontPath, 14); err != nil {
 		return err
 	}
-	for i, symbol := range fileSymbols {
+
+	if o.Inverted {
+		symbols = reverse(fileSymbols)
+	} else {
+		symbols = fileSymbols
+	}
+	for i, symbol := range symbols {
 		var color []int
 		if i%2 == 0 {
 			color = colorLight
@@ -183,7 +215,12 @@ func (r *Renderer) drawRankFile(o Options) error {
 		r.context.DrawString(string(symbol), float64(r.drawSize.gridSize*i+2), float64(o.BoardSize-3))
 	}
 
-	for i, symbol := range rankSymbolsReverse {
+	if o.Inverted {
+		symbols = rankSymbols
+	} else {
+		symbols = reverse(rankSymbols)
+	}
+	for i, symbol := range symbols {
 		var color []int
 		if i%2 == 0 {
 			color = colorLight
@@ -197,7 +234,7 @@ func (r *Renderer) drawRankFile(o Options) error {
 	return nil
 }
 
-func (r *Renderer) drawPiece(piece position, assetPath string, resizer draw.Scaler) error {
+func (r *Renderer) drawPiece(piece position, assetPath string, resizer draw.Scaler, inverted bool) error {
 	// Todo move this to runtime cache function
 	png, err := gg.LoadPNG(assetPath + pieceNames[string(piece.pieceSymbol)])
 	if err != nil {
@@ -209,7 +246,17 @@ func (r *Renderer) drawPiece(piece position, assetPath string, resizer draw.Scal
 	}
 	gridSize := r.drawSize.gridSize
 	pieceOffset := r.drawSize.pieceOffset
-	r.context.DrawImage(resized, gridSize*(piece.tile.rank())+pieceOffset, gridSize*(piece.tile.file())+pieceOffset)
+
+	var pieceRank, pieceFile int
+	if inverted {
+		pieceRank = piece.tile.rankInverted()
+		pieceFile = piece.tile.fileInverted()
+	} else {
+		pieceRank = piece.tile.rank()
+		pieceFile = piece.tile.file()
+	}
+
+	r.context.DrawImage(resized, gridSize*(pieceRank)+pieceOffset, gridSize*(pieceFile)+pieceOffset)
 	return nil
 }
 
@@ -228,4 +275,12 @@ func calcDrawSize(o Options) drawSize {
 		pieceSize:   int(pieceSize),
 		pieceOffset: int((gridSize - pieceSize) / 2),
 	}
+}
+
+func reverse(s string) string {
+	r := []rune(s)
+	for i, j := 0, len(r)-1; i < len(r)/2; i, j = i+1, j-1 {
+		r[i], r[j] = r[j], r[i]
+	}
+	return string(r)
 }


### PR DESCRIPTION
The only difference between `king_checked_inverted.go` and `king_checked.go` is that `king_checked_inverted.go` passes the `Inverted: true` option to the `board.Render` call.

![image](https://user-images.githubusercontent.com/12236085/50731804-a033c200-113b-11e9-93b3-e3cc35aaeb4e.png)
